### PR TITLE
fix: keep device halted after flash. Fix reset call

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,36 @@ This mean that Segger probes are not yet supported here as it requires a `target
 
 ## Usage
 
-This library is built to be use through the `Library` directive of Robot-Framework:
+This library is built to be use through the `Library` directive of Robot-Framework and requires a probe uid
+so that pyOCD is able to discriminate multiple probes being connected.
 
 ```robot
-Library         PyocdLibrary
+Library         PyocdLibrary    ${PROBE_UID}
 ```
 
-It is considered that the pyocd local configuration is made so that the probe is automatically selected in
-case of multiple probes connected to the host.
-This can be done at pyocd local through pyocd configuration (see https://pyocd.io/docs/configuration.html).
-
+By now, if the probe do not delivers a target identifier (like Segger probes), the pyOCD usage do not
+allow a clean connection to the AP.
 As a consequence, this small library do not support probe UID passing through robot ressource files.
 
 The following basic command are defined:
+
+
+### Probe Has Vcp
+
+Return true if a VCP tty port has been found associated to the probe UID.
+
+```robot
+Probe Has Vcp
+```
+
+### Get Probe Vcp
+
+Return the VCP tty name as a string, so that it can be used by other serial related robotframework
+modules to get back the device serial Output.
+
+```robot
+Get Probe Vcp
+```
 
 ### Load Firmware
 
@@ -68,6 +85,27 @@ A typical usage is:
 
 ```robot
 Resume
+```
+
+## Example
+
+A typical usage of this library is the followingr:
+
+```robot
+Library         SerialLibrary
+Library         PyocdLibrary    ${PROBE_UID}
+
+*** Test Cases ***
+
+Load And Read From Serial
+    Reset
+    Load Firmware           ${FIRMWARE_PATH}
+    ${vcp}                  Get Probe Vcp
+    Log                     Virtual port is ${vcp}
+    Connect                 ${vcp}    115200
+    Set Timeout             20
+    Resume
+    Read All
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ license = {file = "LICENSE"}
 dependencies = [
     "robotframework>=7.0.0",
     "pyocd>=0.36.0",
+    "pyudev>=0.24.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/PyocdLibrary/__init__.py
+++ b/src/PyocdLibrary/__init__.py
@@ -41,7 +41,8 @@ class PyocdLibrary():
     def reset(self):
 
         with ConnectHelper.session_with_chosen_probe() as session:
-            while session.board.target.get_state() != Target.State.HALTED:
+            session.board.target.reset_and_halt()
+            while session.board.target.get_state() != session.board.target.State.HALTED:
                 pass
 
     @keyword("Load Firmware")
@@ -52,8 +53,6 @@ class PyocdLibrary():
             # Load firmware into device.
             FileProgrammer(session).program(file)
             session.board.target.reset_and_halt()
-            session.board.target.resume()
-
 
     @keyword("Resume")
     def resume(self):

--- a/src/PyocdLibrary/__init__.py
+++ b/src/PyocdLibrary/__init__.py
@@ -35,28 +35,33 @@ class PyocdLibrary():
     ROBOT_AUTO_KEYWORDS = False
 
     def __init__(self):
+        try:
+            self._session = ConnectHelper.session_with_chosen_probe()
+            self._session.open()
+        except error:
+            print("Connection to probe failed in automatic way");
         return
 
     @keyword("Reset")
     def reset(self):
 
-        with ConnectHelper.session_with_chosen_probe() as session:
-            session.board.target.reset_and_halt()
-            while session.board.target.get_state() != session.board.target.State.HALTED:
-                pass
+        self._session.board.target.reset_and_halt()
+        while self._session.board.target.get_state() != self._session.board.target.State.HALTED:
+            pass
 
     @keyword("Load Firmware")
     def load_firmware(self, file: str):
 
-        with ConnectHelper.session_with_chosen_probe() as session:
-            flash = session.board.target.memory_map.get_boot_memory()
-            # Load firmware into device.
-            FileProgrammer(session).program(file)
-            session.board.target.reset_and_halt()
+        flash = self._session.board.target.memory_map.get_boot_memory()
+        # Load firmware into device.
+        FileProgrammer(self._session).program(file)
+        self._session.board.target.reset_and_halt()
 
     @keyword("Resume")
     def resume(self):
-        with ConnectHelper.session_with_chosen_probe() as session:
-            session.board.target.resume()
+        self._session.board.target.resume()
+
+    def __del__(self):
+        self._session.close()
 
 __all__ = ["__version__", "PyocdLibrary"]


### PR DESCRIPTION
Avoid to resume after flash, to let the robot script decide when to resume.
Fix invalid syntax in reset API
Add support for automatic deduction from probe uid of the VCP tty name